### PR TITLE
Adding Files for OSS Process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,22 @@
+## Overview
+
+Explain your changes, including any issues or relevant context about why they are needed.
+
+## Security
+
+REMINDER: All file contents are public.
+
+- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
+- [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
+- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.
+
+Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.
+
+Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
+
+## Reviewers
+
+Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
+- Subject-matter experts
+- Style/editing reviewers
+- Others requested by the content owner

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 CareEvolution
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+This repo contains various example apps demonstrating different ways of utilizing the [CareEvolution FHIR interface](https://fhir.docs.careevolution.com/).


### PR DESCRIPTION
Per OSS process best practices:

- Added a license file to the root level (there were some files and comments in the various subfolders already referencing the MIT license)
- Added a simple readme.
- Added a PR template.

Also, since we have multiple public repos now, I think it would be helpful to rename this one - maybe "PublicFHIRDemos".