### PR TITLE
SMARTest: show the id_token if it's in response

### DIFF
--- a/SMARTest/SMARTest.html
+++ b/SMARTest/SMARTest.html
@@ -86,6 +86,13 @@
                 <label for="refreshToken">Refresh token:</label>
                 <input type="text" class="form-control" id="refreshToken" ng-model="refreshToken" readonly>
             </div>
+            <div class="form-group" ng-show="idToken">
+                <label for="idToken">ID token:</label>
+                <input type="text" class="form-control" id="idToken" ng-model="idToken" readonly>
+                <p>
+                    <a ng-href="https://jwt.io/#token={{ idToken }}" target="_blank">View on jwt.io</a>
+                </p>
+            </div>
             <div class="form-group" ng-show="responseScope">
                 <label for="responseScope">Returned scopes:</label>
                 <input type="text" class="form-control" id="responseScope" ng-model="responseScope" readonly>

--- a/SMARTest/Scripts/SMARTest.js
+++ b/SMARTest/Scripts/SMARTest.js
@@ -46,6 +46,7 @@
 		var SESSION_PATIENT_ID = "patientID";
 		var SESSION_REFRESH_TOKEN = "refreshToken";
 		var SESSION_RESPONSE_SCOPE = "responseScope";
+		var SESSION_ID_TOKEN = "idToken";
 
         $scope.redirectUrl = window.location.protocol + "//" + window.location.host + window.location.pathname;
 
@@ -105,7 +106,7 @@
 			setSessionStorage(SESSION_CLIENT_SECRET, $scope.clientSecret);
 			setSessionStorage(SESSION_SCOPE, $scope.scope);
 			setSessionStorage(SESSION_LAUNCH, $scope.launch);
-			setAccessToken(null, null, null, null);
+			setAccessToken(null, null, null, null, null);
 			getFhirMetadata(
 				function(smartUrls) {
 					var redirectParameters = "";
@@ -133,6 +134,7 @@
 		$scope.refreshToken = sessionStorage[SESSION_REFRESH_TOKEN] || null;
 		$scope.patientID = sessionStorage[SESSION_PATIENT_ID] || null;
 		$scope.responseScope = sessionStorage[SESSION_RESPONSE_SCOPE] || null;
+		$scope.idToken = sessionStorage[SESSION_ID_TOKEN] || null;
 
 		$scope.refreshTokenMessage = null;
 		$scope.refreshingToken = false;
@@ -225,7 +227,7 @@
 						redirect_uri: $scope.redirectUrl,
 					},
 					function(data) {
-						setAccessToken(data.access_token, data.refresh_token, data.patient, data.scope);
+						setAccessToken(data.access_token, data.refresh_token, data.patient, data.scope, data.id_token);
 						window.location = $scope.redirectUrl;
 					},
 					function(errorMessage) {
@@ -249,7 +251,7 @@
 			return null;
 		}
 
-		function setAccessToken(token, refreshToken, patientID, responseScope) {
+		function setAccessToken(token, refreshToken, patientID, responseScope, idToken) {
 			$scope.accessToken = token;
 			setSessionStorage(SESSION_ACCESS_TOKEN, token);
 			$scope.refreshToken = refreshToken;
@@ -258,6 +260,8 @@
 			setSessionStorage(SESSION_PATIENT_ID, patientID);
 			$scope.responseScope = responseScope;
 			setSessionStorage(SESSION_RESPONSE_SCOPE, responseScope);
+			$scope.idToken = idToken;
+			setSessionStorage(SESSION_ID_TOKEN, idToken);
 		}
 
 		function setSessionStorage(key, value) {


### PR DESCRIPTION
## Overview

Also show the id_token if it's in the response, i.e. you used the `openid` scope

<img width="1443" height="1065" alt="image" src="https://github.com/user-attachments/assets/f5c8b7b9-aa13-46cf-97c3-e732630ec76b" />

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
- [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

ID tokens are short-lived, this is a development/testing tool, jwt.io is hosted by a well-known entity (Auth0), using hash fragment so it's not sent to any server, and ID tokens are frequently present in browser history already (if using the implicit flow).
